### PR TITLE
Don't hide import errors

### DIFF
--- a/calibre-plugin/__init__.py
+++ b/calibre-plugin/__init__.py
@@ -114,24 +114,16 @@ class DeACSM(FileTypePlugin):
                 from calibre_plugins.deacsm.libadobe import VAR_HOBBES_VERSION, createDeviceKeyFile, update_account_path
                 from calibre_plugins.deacsm.libadobeAccount import createDeviceFile, createUser, signIn, activateDevice
             except: 
-                try: 
-                    from libadobe import VAR_HOBBES_VERSION, createDeviceKeyFile, update_account_path
-                    from libadobeAccount import createDeviceFile, createUser, signIn, activateDevice
-                except: 
-                    print("{0} v{1}: Error while importing Account stuff".format(PLUGIN_NAME, PLUGIN_VERSION))
-                    traceback.print_exc()
+                from libadobe import VAR_HOBBES_VERSION, createDeviceKeyFile, update_account_path
+                from libadobeAccount import createDeviceFile, createUser, signIn, activateDevice
 
             # Fulfill:
             try: 
                 from calibre_plugins.deacsm.libadobe import sendHTTPRequest
                 from calibre_plugins.deacsm.libadobeFulfill import buildRights, fulfill
             except: 
-                try: 
-                    from libadobe import sendHTTPRequest
-                    from libadobeFulfill import buildRights, fulfill
-                except: 
-                    print("{0} v{1}: Error while importing Fulfillment stuff".format(PLUGIN_NAME, PLUGIN_VERSION))
-                    traceback.print_exc()
+                from libadobe import sendHTTPRequest
+                from libadobeFulfill import buildRights, fulfill
 
             import calibre_plugins.deacsm.prefs as prefs     # type: ignore
             deacsmprefs = prefs.DeACSM_Prefs()
@@ -184,21 +176,13 @@ class DeACSM(FileTypePlugin):
             from calibre_plugins.deacsm.libadobe import sendHTTPRequest_DL2FILE
             from calibre_plugins.deacsm.libadobeFulfill import buildRights, fulfill
         except: 
-            try: 
-                from libadobe import sendHTTPRequest_DL2FILE
-                from libadobeFulfill import buildRights, fulfill
-            except: 
-                print("{0} v{1}: Error while importing Fulfillment stuff".format(PLUGIN_NAME, PLUGIN_VERSION))
-                traceback.print_exc()
+            from libadobe import sendHTTPRequest_DL2FILE
+            from libadobeFulfill import buildRights, fulfill
 
         try:
             from calibre_plugins.deacsm.libpdf import patch_drm_into_pdf
         except: 
-            try: 
-                from libpdf import patch_drm_into_pdf
-            except: 
-                print("{0} v{1}: Error while importing PDF patch".format(PLUGIN_NAME, PLUGIN_VERSION))
-                traceback.print_exc()
+            from libpdf import patch_drm_into_pdf
 
 
         adobe_fulfill_response = etree.fromstring(replyData)
@@ -301,13 +285,8 @@ class DeACSM(FileTypePlugin):
             from calibre_plugins.deacsm.libadobe import sendHTTPRequest
             from calibre_plugins.deacsm.libadobeFulfill import buildRights, fulfill
         except: 
-            try: 
-                from libadobe import sendHTTPRequest
-                from libadobeFulfill import buildRights, fulfill
-            except: 
-                print("{0} v{1}: Error while importing Fulfillment stuff".format(PLUGIN_NAME, PLUGIN_VERSION))
-                traceback.print_exc()
-
+            from libadobe import sendHTTPRequest
+            from libadobeFulfill import buildRights, fulfill
 
         import calibre_plugins.deacsm.prefs as prefs     # type: ignore
         deacsmprefs = prefs.DeACSM_Prefs()


### PR DESCRIPTION
Hi @Leseratte10 ,

I had the same errors as @Hellmark in issue #2 , that is, `local variable 'update_account_path' referenced before assignment` when trying to add the plugin. It turned out the problem was an import error inside libadobe. However, since `import libadobe` is inside a try/except block that prints something then throws away the exception, I was unable to see the actual error; even the "show details" button in Calibre would not print the error.

This PR replaces the inner `try: import ... except: print(...)` pattern with a simple `import` , so that the actual error is shown by calibre.

Beyond that, why are the imports not at the top of the file as is usual?