### PR TITLE
Decode serial from bytes before concatenation in libadobe.py

### DIFF
--- a/calibre-plugin/libadobe.py
+++ b/calibre-plugin/libadobe.py
@@ -235,7 +235,7 @@ def makeFingerprint(serial):
         devkey_bytes = f.read()
         f.close()
 
-    str_to_hash = serial + devkey_bytes.decode('latin-1')
+    str_to_hash = serial.decode('latin-1') + devkey_bytes.decode('latin-1')
     hashed_str = hashlib.sha1(str_to_hash.encode('latin-1')).digest()
     b64str = base64.b64encode(hashed_str)
 


### PR DESCRIPTION
Without this, on Python 3.9.7 and Python 3.10.12, running `python3 register_ADE_account.py` would result in this stacktrace:

```
Traceback (most recent call last):
  File "/root/register_ADE_account.py", line 78, in <module>
    main()
  File "/root/register_ADE_account.py", line 50, in main
    success = createDeviceFile(True, VAR_VER)
  File "/root/libadobeAccount.py", line 64, in createDeviceFile
    fingerprint = makeFingerprint(serial)
  File "/root/libadobe.py", line 249, in makeFingerprint
    str_to_hash = serial + devkey_bytes.decode('latin-1')
TypeError: can't concat str to bytes
```