### PR TITLE
Fix imports for FreeBSD

### DIFF
--- a/calibre-plugin/__init__.py
+++ b/calibre-plugin/__init__.py
@@ -282,7 +282,10 @@ class ACSMInput(FileTypePlugin):
 
             sys.path.insert(0, os.path.join(self.moddir, "oscrypto"))
             sys.path.insert(0, os.path.join(self.moddir, "asn1crypto"))
-            
+
+            # Sometimes, we don't seem to automatically have our dir in sys.path, add it
+            sys.path.insert(0, os.path.dirname(__file__))
+
             # Okay, now all the modules are available, import the Adobe modules.
 
             from libadobe import createDeviceKeyFile, update_account_path, sendHTTPRequest

--- a/calibre-plugin/config.py
+++ b/calibre-plugin/config.py
@@ -12,7 +12,7 @@ For more information, see:
 https://github.com/Leseratte10/acsm-calibre-plugin
 '''
 
-import os, base64, traceback
+import os, base64, sys, traceback
 from PyQt5.QtGui import QKeySequence
 
 from lxml import etree


### PR DESCRIPTION
On recent versions of Calibre on BSD-based OSes, it appears that the plugin root directory (or ZIP file) is not always automatically added to the import path.

While we could change the plugin to always import using Calibre's plugin import system (eg: `import calibre_plugins.deacsm.libadobe`), that would be an invasive change. Instead, just force the directory/ZIP containing `__init__.py` to always be in the import path. A bit of a hack, but it works.

Also fix a missing `sys` import.

Tested on Calibre 7.8. Working:
* Loading plugin from ZIP into Calibre
* Starting Calibre with the plugin installed
* Viewing and using the plugin prefs
* Fulfilling and decrypting an ACSM file
* Running tests/main.py, with the exception of "Check if the plugin is capable of extracting pkcs12 key". That fails due to RC2 being obsolete and excluded from most modern versions of libcrypto, which doesn't seem worth trying to fix in this PR