### PR TITLE
feat: make libcrypto and libssl paths overrideable

### DIFF
--- a/calibre-plugin/__init__.py
+++ b/calibre-plugin/__init__.py
@@ -285,6 +285,20 @@ class ACSMInput(FileTypePlugin):
             
             # Okay, now all the modules are available, import the Adobe modules.
 
+            # Crucial to import first, as libadobe imports oscrypto as well
+
+            libcrypto_path = os.environ["ACSM_LIBCRYPTO"]
+            libssl_path = os.environ["ACSM_LIBSSL"]
+
+            if os.path.exists(libcrypto_path) and os.path.exists(libssl_path):
+                import oscrypto
+
+                oscrypto.use_openssl(
+                    libcrypto_path = libcrypto_path,
+                    libssl_path = libssl_path,
+                )
+
+
             from libadobe import createDeviceKeyFile, update_account_path, sendHTTPRequest
             from libadobeAccount import createDeviceFile, createUser, signIn, activateDevice
             from libadobeFulfill import buildRights, fulfill


### PR DESCRIPTION
Allows overriding libcrypto and libssl paths by setting `ACSM_LIBCRYPTO` and `ACSM_LIBSSL` (both are necessary).

This is necessary to properly use the plugin on NixOS where library paths change quite frequently and are not necessarily in the scope of an application.

related to #68 
closes #94